### PR TITLE
Build for python 3.7

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -56,6 +56,7 @@ time docker run \
 echo "--- Running tests ..."
 TEST_IMAGE="test-${BUILDKITE_JOB_ID}"
 docker commit "${BUILD_CONTAINER}" "${TEST_IMAGE}"
+docker rm "${BUILD_CONTAINER}"
 R=0
 time docker run --rm -i \
   -v "$(pwd):/src" \
@@ -81,4 +82,3 @@ else
   echo "--- ✅ GDAL tests passed!"
 fi
 
-docker rm "${BUILD_CONTAINER}"

--- a/gdal/debian/control
+++ b/gdal/debian/control
@@ -4,6 +4,7 @@ Uploaders: Francesco Paolo Lovergine <frankie@debian.org>,
            Bas Couwenberg <sebastic@debian.org>
 Section: science
 Priority: optional
+X-Python3-Version: 3.7
 Build-Depends: debhelper (>= 9.20160114),
                dh-autoreconf,
                dh-python,
@@ -52,9 +53,7 @@ Build-Depends: debhelper (>= 9.20160114),
                patch,
                python-all-dev (>= 2.6.6-3~),
                python-numpy,
-               python3-all-dev,
-               python3-numpy,
-               python3-distutils,
+               python3.7-dev,
                swig,
                unixodbc-dev (>= 2.2.11),
                zlib1g-dev,

--- a/gdal/debian/rules
+++ b/gdal/debian/rules
@@ -34,7 +34,7 @@ include /usr/share/dpkg/buildflags.mk
 
 UPSTREAM_VERSION = $(shell echo $(DEB_VERSION_UPSTREAM) | sed -e 's/\+.*//')
 
-PYVERS=$(shell pyversions -v -r debian/control) $(shell py3versions -v -r)
+PYVERS=2.7 3.7
 PYDEF=$(shell pyversions -dv)
 PERLDEF=$(shell perl -V:version|cut -d\' -f2)
 SWIGVER=$(shell swig -version |grep Version|cut -d' ' -f3|sed -e 's/\.//g')
@@ -236,7 +236,6 @@ override_dh_python2:
 
 override_dh_python3:
 	dh_python3 -X.info -ppython3-gdal
-	dh_numpy3 -ppython3-gdal
 
 override_dh_makeshlibs:
 	# Forces failure ignoring to collect new symbols on all archs


### PR DESCRIPTION
Builds for python 3.7 instead of 3.6

We assume that numpy is not required here. This will break some scripts like `gdal_calc.py` when invoked with the system python interpreter. This just means that we have to invoke it via an interpreter from a virtualenv which has numpy installed.

distutils appears to be included in the `python3.7` package, so we don't need to depend on it separately